### PR TITLE
feat: change config hook to configResolved, avoid cacheDir different …

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,13 @@ const defaultCacheDir = 'node_modules/.vite'
 function viteBasicSslPlugin(): Plugin {
   return {
     name: 'vite:basic-ssl',
-    async config(config) {
+    async configResolved(config) {
       const certificate = await getCertificate((config.cacheDir ?? defaultCacheDir) + '/basic-ssl')
       const https = () => ({ 
         https: { cert: certificate, key: certificate }
       })
-      return {
-        server: https(),
-        preview: https()
-      }
+      config.server.https = Object.assign({}, config.server.https, https())
+      config.preview.https = Object.assign({}, config.preview.https, https())
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-extraneous-import */
 import path from 'node:path'
 import { promises as fsp } from 'node:fs'
 import type { Plugin } from 'vite'


### PR DESCRIPTION
we can't get cacheDir config before `config` hook;
to keep the same with other steps, change `config` hook to `configResolved`, so that we can get the whole config 