### PR TITLE
Support custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ import basicSsl from '@vitejs/plugin-basic-ssl'
 
 export default {
   plugins: [
-    basicSsl()
+    basicSsl({
+      /** name of certification */
+      name: 'test',
+      /** custom trust domains */
+      domains: ['*.custom.com'],
+      /** custom certification directory */
+      certDir: '/Users/.../.devServer/cert'
+    })
   ]
 }
 ```
- 
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/plugin-basic-ssl",
   "version": "1.0.2",
   "license": "MIT",
+  "type": "module",
   "author": "Evan You and Vite Contributors",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@vitejs/plugin-basic-ssl",
   "version": "1.0.2",
   "license": "MIT",
-  "type": "module",
   "author": "Evan You and Vite Contributors",
   "files": [
     "dist"

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -52,7 +52,7 @@ function toPositiveHex(hexString: string) {
   return mostSignificativeHexAsInt.toString() + hexString.substring(1)
 }
 
-export function createCertificate(name: string, domains?: string[]): string {
+export function createCertificate(name: string = 'example.org', domains?: string[]): string {
   const days = 30
   const keySize = 2048
 

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -61,6 +61,10 @@ export function createCertificate(name: string, domains?: string[]): string {
     : []
 
   const extensions = [
+    // {
+    //   name: 'basicConstraints',
+    //   cA: true,
+    // },
     {
       name: 'keyUsage',
       keyCertSign: true,
@@ -87,6 +91,14 @@ export function createCertificate(name: string, domains?: string[]): string {
         {
           type: 2,
           value: 'localhost.localdomain'
+        },
+        {
+          type: 2,
+          value: 'lvh.me'
+        },
+        {
+          type: 2,
+          value: '*.lvh.me'
         },
         {
           type: 2,

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -52,15 +52,15 @@ function toPositiveHex(hexString: string) {
   return mostSignificativeHexAsInt.toString() + hexString.substring(1)
 }
 
-export function createCertificate(): string {
+export function createCertificate(name: string, domains?: string[]): string {
   const days = 30
   const keySize = 2048
 
+  const appendDomains = domains
+    ? domains.map(item => ({ type: 2, value: item }))
+    : []
+
   const extensions = [
-    // {
-    //   name: 'basicConstraints',
-    //   cA: true,
-    // },
     {
       name: 'keyUsage',
       keyCertSign: true,
@@ -90,14 +90,6 @@ export function createCertificate(): string {
         },
         {
           type: 2,
-          value: 'lvh.me'
-        },
-        {
-          type: 2,
-          value: '*.lvh.me'
-        },
-        {
-          type: 2,
           value: '[::1]'
         },
         {
@@ -108,7 +100,8 @@ export function createCertificate(): string {
         {
           type: 7,
           ip: 'fe80::1'
-        }
+        },
+        ...appendDomains
       ]
     }
   ]
@@ -116,7 +109,7 @@ export function createCertificate(): string {
   const attrs = [
     {
       name: 'commonName',
-      value: 'example.org'
+      value: name
     },
     {
       name: 'countryName',

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { promises as fsp } from 'node:fs'
 import type { Plugin } from 'vite'
 
 const defaultCacheDir = 'node_modules/.vite'
-const defaultName = 'example.org'
 
 interface Options {
   certDir: string
@@ -17,7 +16,7 @@ function viteBasicSslPlugin(options?: Partial<Options>): Plugin {
     async configResolved(config) {
       const certificate = await getCertificate(
         options?.certDir ?? (config.cacheDir ?? defaultCacheDir) + '/basic-ssl',
-        options?.name ?? defaultName,
+        options?.name,
         options?.domains
       )
       const https = () => ({ cert: certificate, key: certificate })
@@ -29,7 +28,7 @@ function viteBasicSslPlugin(options?: Partial<Options>): Plugin {
 
 export async function getCertificate(
   cacheDir: string,
-  name: string,
+  name?: string,
   domains?: string[]
 ) {
   const cachePath = path.join(cacheDir, '_cert.pem')


### PR DESCRIPTION
This PR introduces the following features: 
1. Custom domains
2. Custom cert directory
3. Custom name of certification

Can be easily set by:
```js
// vite.config.js
import basicSsl from '@vitejs/plugin-basic-ssl'

export default {
  plugins: [
    basicSsl({name: "test", domains: ["*.custom.com"], certDir: "/Users/.../.devServer/cert"})
  ]
}
```

Some essential options can make our local development more comfortable. In Chrome, there will not be unfriendly security warnings.