### PR TITLE
docs: add `server.proxy` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ In most scenarios, it is recommended to generate a secure trusted certificate in
 
 ```js
 // vite.config.js
-import basicSsl from '@vitejs/plugin-basic-ssl'
+import basicSsl from '@vitejs/plugin-basic-ssl';
 
+/** @type {import('vite').UserConfig} */
 export default {
   plugins: [
     basicSsl({
@@ -20,8 +21,10 @@ export default {
       /** custom certification directory */
       certDir: '/Users/.../.devServer/cert'
     })
-  ]
-}
+  ],
+  /** Required in Node.js v20+ */
+  server: { proxy: {} }
+};
 ```
 
 ## License


### PR DESCRIPTION
All credit goes to [`u/konstantinblaesi`](https://www.reddit.com/r/sveltejs/comments/1co07iz/comment/l7efmle/).

If the `server.proxy` is not set, the following error is shown in the browser.

```
TypeError: Could not convert argument of type symbol to string.
  at webidl.converters.DOMString (node:internal/deps/undici/undici:1977:15)
  at webidl.converters.ByteString (node:internal/deps/undici/undici:1982:35)
  at Object.record<ByteString, ByteString> (node:internal/deps/undici/undici:1894:30)
  at webidl.converters.HeadersInit (node:internal/deps/undici/undici:3424:67)
  at Object.RequestInit (node:internal/deps/undici/undici:1951:21)
  at new Request (node:internal/deps/undici/undici:4835:34)
```

Reproducible in the following environment.

```
Binaries:
  Node: 20.14.0 - ~/.local/state/fnm_multishells/43230_1718006277694/bin/node
  npm: 10.7.0 - ~/.local/state/fnm_multishells/43230_1718006277694/bin/npm
  pnpm: 9.2.0 - ~/.local/state/fnm_multishells/43230_1718006277694/bin/pnpm
npmPackages:
  @vitejs/plugin-basic-ssl: ^1.1.0 => 1.1.0 
  vite: ^5.2.13 => 5.2.13 
  vitest: ^1.6.0 => 1.6.0 
```