### PR TITLE
fix!: remove lvh.me from the certificate

### DIFF
--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -97,14 +97,6 @@ export function createCertificate(
         },
         {
           type: 2,
-          value: 'lvh.me',
-        },
-        {
-          type: 2,
-          value: '*.lvh.me',
-        },
-        {
-          type: 2,
           value: '[::1]',
         },
         {


### PR DESCRIPTION
fixes vitejs/vite-plugin-basic-ssl#65

`lvh.me`, for me at least, no longer resolves to 127.0.0.1.  Recent changes to vite now look at the certificate and list the alt hosts as possible ways to access the vite dev server.

before
```
  VITE v6.1.0  ready in 367 ms

  ➜  Local:   https://localhost:5173/
  ➜  Local:   https://localhost.localdomain:5173/
  ➜  Local:   https://lvh.me:5173/
  ➜  Local:   https://vite.lvh.me:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
```

after this PR
```
  VITE v6.1.0  ready in 387 ms

  ➜  Local:   https://localhost:5173/
  ➜  Local:   https://localhost.localdomain:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
```

Users will need to removed the certificate they already have.