### PR TITLE
fix!: remove localhost.localdomain from the certificate

### DIFF
--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -93,10 +93,6 @@ export function createCertificate(
         },
         {
           type: 2,
-          value: 'localhost.localdomain',
-        },
-        {
-          type: 2,
           value: 'lvh.me',
         },
         {


### PR DESCRIPTION
`.localdomain` is non-standard. Similar to #67