### PR TITLE
chore: support Vite v7 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-basic-ssl/#readme",
   "peerDependencies": {
-    "vite": "^6.0.0"
+    "vite": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.8",


### PR DESCRIPTION
closes https://github.com/vitejs/vite-plugin-basic-ssl/issues/73